### PR TITLE
Fix audio

### DIFF
--- a/EFI/OC/Kexts/UTBMap.kext/Contents/Info.plist
+++ b/EFI/OC/Kexts/UTBMap.kext/Contents/Info.plist
@@ -22,7 +22,7 @@
 	<string>1.1</string>
 	<key>IOKitPersonalities</key>
 	<dict>
-		<key>7:0:3</key>
+		<key>XHC0</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>com.dhinakg.USBToolBox.kext</string>
@@ -30,11 +30,8 @@
 			<string>USBToolBox</string>
 			<key>IOMatchCategory</key>
 			<string>USBToolBox</string>
-			<key>IOPropertyMatch</key>
-			<dict>
-				<key>pcidebug</key>
-				<string>7:0:3</string>
-			</dict>
+			<key>IONameMatch</key>
+			<string>XHC0</string>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
 			<key>IOProviderMergeProperties</key>
@@ -45,7 +42,7 @@
 				</data>
 				<key>ports</key>
 				<dict>
-					<key>PRT1</key>
+					<key>HS01</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>9</integer>
@@ -54,7 +51,7 @@
 						AQAAAA==
 						</data>
 					</dict>
-					<key>PRT2</key>
+					<key>HS02</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>3</integer>
@@ -63,16 +60,7 @@
 						AgAAAA==
 						</data>
 					</dict>
-					<key>PRT3</key>
-					<dict>
-						<key>UsbConnector</key>
-						<integer>0</integer>
-						<key>port</key>
-						<data>
-						AwAAAA==
-						</data>
-					</dict>
-					<key>PRT4</key>
+					<key>HS03</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>255</integer>
@@ -81,7 +69,7 @@
 						BAAAAA==
 						</data>
 					</dict>
-					<key>PRT5</key>
+					<key>SS01</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>9</integer>
@@ -90,7 +78,7 @@
 						BQAAAA==
 						</data>
 					</dict>
-					<key>PRT6</key>
+					<key>SS02</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>3</integer>
@@ -102,7 +90,7 @@
 				</dict>
 			</dict>
 		</dict>
-		<key>7:0:4</key>
+		<key>XHC1</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>com.dhinakg.USBToolBox.kext</string>
@@ -110,11 +98,8 @@
 			<string>USBToolBox</string>
 			<key>IOMatchCategory</key>
 			<string>USBToolBox</string>
-			<key>IOPropertyMatch</key>
-			<dict>
-				<key>pcidebug</key>
-				<string>7:0:4</string>
-			</dict>
+			<key>IONameMatch</key>
+			<string>XHC1</string>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
 			<key>IOProviderMergeProperties</key>
@@ -125,7 +110,7 @@
 				</data>
 				<key>ports</key>
 				<dict>
-					<key>PRT1</key>
+					<key>HS01</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>9</integer>
@@ -134,7 +119,7 @@
 						AQAAAA==
 						</data>
 					</dict>
-					<key>PRT2</key>
+					<key>HS02</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>3</integer>
@@ -143,16 +128,7 @@
 						AgAAAA==
 						</data>
 					</dict>
-					<key>PRT3</key>
-					<dict>
-						<key>UsbConnector</key>
-						<integer>0</integer>
-						<key>port</key>
-						<data>
-						AwAAAA==
-						</data>
-					</dict>
-					<key>PRT4</key>
+					<key>HS03</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>255</integer>
@@ -161,7 +137,7 @@
 						BAAAAA==
 						</data>
 					</dict>
-					<key>PRT5</key>
+					<key>SS01</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>9</integer>
@@ -170,7 +146,7 @@
 						BQAAAA==
 						</data>
 					</dict>
-					<key>PRT6</key>
+					<key>SS02</key>
 					<dict>
 						<key>UsbConnector</key>
 						<integer>3</integer>


### PR DESCRIPTION
升级V1.1.0后usb audio 失效
参照 [https://github.com/daliansky/minisforum-HX90G-Hackintosh/issues/3](url) 定制USB后修复