### PR TITLE
Update config.plist fix ipc_control_port_options=0

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1521,7 +1521,7 @@
                     <key>SystemAudioVolume</key>
                     <data>Rg==</data>
                     <key>boot-args</key>
-                    <string>amfi=0x80 revpatch=sbvmm revblock=pci keepsyms=1 debug=0x100 -lilubetaall</string>
+                    <string>amfi=0x80 revpatch=sbvmm revblock=pci keepsyms=1 debug=0x100 -lilubetaall ipc_control_port_options=0</string>
                     <key>csr-active-config</key>
                     <data>AwgAAA==</data>
                     <key>prev-lang:kbd</key>


### PR DESCRIPTION
升级 Sonoma 可能会导致一些软件，比如钉钉、AnotherRedisDesktop等出现闪退的问题，与白苹果关闭SIP产生的问题一样，向 Nvram 里增加启动参数 ipc_control_port_options=0，可以解决这个问题。